### PR TITLE
set timezone

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -425,4 +425,3 @@ jobs:
       - name: Run tests
         run: |
           pytest --ignore-flavors --ignore=tests/projects tests
-      - 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -414,6 +414,7 @@ jobs:
           node-version: 10.x
       - name: Run timezone test
         working-directory: mlflow/server/js
+        shell: pwsh
         run: |
           tzutil /s "Tokyo Standard Time"
           npm i

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -415,6 +415,7 @@ jobs:
       - name: Run timezone test
         working-directory: mlflow/server/js
         run: |
+          npm i
           npm run test -t timezone --verbose
       - name: Install dependecies
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -419,6 +419,7 @@ jobs:
           tzutil /s "Tokyo Standard Time"
           npm i
           npm run test -t timezone --verbose
+          tzutil /g
       - name: Install dependecies
         run: |
           pip install -r dev-requirements.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -415,6 +415,7 @@ jobs:
       - name: Run timezone test
         working-directory: mlflow/server/js
         run: |
+          tzutil /s "Tokyo Standard Time"
           npm i
           npm run test -t timezone --verbose
       - name: Install dependecies

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -408,6 +408,14 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Run timezone test
+        working-directory: mlflow/server/js
+        run: |
+          npm run test -t timezone --verbose
       - name: Install dependecies
         run: |
           pip install -r dev-requirements.txt
@@ -417,3 +425,4 @@ jobs:
       - name: Run tests
         run: |
           pytest --ignore-flavors --ignore=tests/projects tests
+      - 

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -80,8 +80,8 @@
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired --max_old_space_size=8192 build",
-    "test": "TZ=GMT react-app-rewired test --env=jsdom --colors",
-    "test:debug": "TZ=GMT react-app-rewired --inspect-brk test --runInBand --no-cache --env=jsdom",
+    "test": "react-app-rewired test --env=jsdom --colors --verbose",
+    "test:debug": "react-app-rewired --inspect-brk test --runInBand --no-cache --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
@@ -101,7 +101,8 @@
     "setupFiles": [
       "jest-canvas-mock",
       "<rootDir>/scripts/throw-on-prop-type-warning.js"
-    ]
+    ],
+    "globalSetup": "<rootDir>/scripts/global-setup.js"
   },
   "browserslist": [
     "defaults"

--- a/mlflow/server/js/scripts/global-setup.js
+++ b/mlflow/server/js/scripts/global-setup.js
@@ -12,7 +12,7 @@ module.exports = () => {
       execSync(`tzutil /s "${previousTZ}"`);
       console.log(`timezone was restored to ${previousTZ}`);
     };
-    execSync(`tzutil /s "GMT"`);
+    execSync(`tzutil /s "GMT Standard Time"`);
     console.warn(`timezone changed, if process is killed, run manually: tzutil /s "${previousTZ}"`);
     process.on('exit', cleanup);
     process.on('SIGINT', function() {

--- a/mlflow/server/js/scripts/global-setup.js
+++ b/mlflow/server/js/scripts/global-setup.js
@@ -1,0 +1,24 @@
+const { execSync } = require('child_process');
+const os = require('os');
+
+// How do I set a timezone in my Jest config?
+// https://stackoverflow.com/a/56482581/6943581
+
+module.exports = () => {
+  // Take from: https://github.com/capaj/set-tz/blob/master/index.js
+  if (os.platform() === 'win32') {
+    const previousTZ = execSync('tzutil /g').toString();
+    const cleanup = () => {
+      execSync(`tzutil /s "${previousTZ}"`);
+      console.log(`timezone was restored to ${previousTZ}`);
+    };
+    execSync(`tzutil /s "GMT Standard Time"`);
+    console.warn(`timezone changed, if process is killed, run manually: tzutil /s "${previousTZ}"`);
+    process.on('exit', cleanup);
+    process.on('SIGINT', function() {
+      process.exit(2);
+    });
+  } else {
+    process.env.TZ = 'GMT';
+  }
+};

--- a/mlflow/server/js/scripts/global-setup.js
+++ b/mlflow/server/js/scripts/global-setup.js
@@ -12,7 +12,7 @@ module.exports = () => {
       execSync(`tzutil /s "${previousTZ}"`);
       console.log(`timezone was restored to ${previousTZ}`);
     };
-    execSync(`tzutil /s "GMT Standard Time"`);
+    execSync(`tzutil /s "GMT"`);
     console.warn(`timezone changed, if process is killed, run manually: tzutil /s "${previousTZ}"`);
     process.on('exit', cleanup);
     process.on('SIGINT', function() {

--- a/mlflow/server/js/scripts/global-setup.js
+++ b/mlflow/server/js/scripts/global-setup.js
@@ -12,7 +12,7 @@ module.exports = () => {
       execSync(`tzutil /s "${previousTZ}"`);
       console.log(`timezone was restored to ${previousTZ}`);
     };
-    execSync(`tzutil /s "GMT Standard Time"`);
+    // execSync(`tzutil /s "GMT Standard Time"`);
     console.warn(`timezone changed, if process is killed, run manually: tzutil /s "${previousTZ}"`);
     process.on('exit', cleanup);
     process.on('SIGINT', function() {

--- a/mlflow/server/js/scripts/global-setup.js
+++ b/mlflow/server/js/scripts/global-setup.js
@@ -12,7 +12,7 @@ module.exports = () => {
       execSync(`tzutil /s "${previousTZ}"`);
       console.log(`timezone was restored to ${previousTZ}`);
     };
-    // execSync(`tzutil /s "GMT Standard Time"`);
+    execSync(`tzutil /s "GMT Standard Time"`);
     console.warn(`timezone changed, if process is killed, run manually: tzutil /s "${previousTZ}"`);
     process.on('exit', cleanup);
     process.on('SIGINT', function() {

--- a/mlflow/server/js/src/common/timezone.test.js
+++ b/mlflow/server/js/src/common/timezone.test.js
@@ -1,0 +1,4 @@
+test('timezone is GMT', () => {
+  const d = new Date();
+  expect(d.getTimezoneOffset()).toBe(0);
+});


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
