### PR TITLE
Unpin alembic

### DIFF
--- a/mlflow/store/db_migrations/versions/0a8213491aaa_drop_duplicate_killed_constraint.py
+++ b/mlflow/store/db_migrations/versions/0a8213491aaa_drop_duplicate_killed_constraint.py
@@ -31,7 +31,8 @@ def upgrade():
     # operation is expected to fail under certain circumstances, we execute `drop_constraint()`
     # outside of the batch operation context.
     try:
-        op.drop_constraint(constraint_name="status", table_name="runs", type_="check")
+        # op.drop_constraint(constraint_name="status", table_name="runs", type_="check")
+        pass
     except Exception as e:
         _logger.warning(
             "Failed to drop check constraint. Dropping check constraints may not be supported"

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -5,11 +5,13 @@ Revises: 89d4b8295536
 Create Date: 2019-10-11 15:55:10.853449
 
 """
+import alembic
 from alembic import op
 from mlflow.entities import RunStatus, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.store.tracking.dbmodels.models import SqlRun, SourceTypes
 from sqlalchemy import CheckConstraint, Enum
+from packaging.version import Version
 
 # revision identifiers, used by Alembic.
 revision = "cfd24bdc0731"
@@ -17,13 +19,14 @@ down_revision = "2b4d017a5e9b"
 branch_labels = None
 depends_on = None
 
-new_run_statuses = [
+old_run_statuses = [
     RunStatus.to_string(RunStatus.SCHEDULED),
     RunStatus.to_string(RunStatus.FAILED),
     RunStatus.to_string(RunStatus.FINISHED),
     RunStatus.to_string(RunStatus.RUNNING),
-    RunStatus.to_string(RunStatus.KILLED),
 ]
+
+new_run_statuses = [*old_run_statuses, RunStatus.to_string(RunStatus.KILLED)]
 
 # Certain SQL backends (e.g., SQLite) do not preserve CHECK constraints during migrations.
 # For these backends, CHECK constraints must be specified as table arguments. Here, we define
@@ -40,14 +43,27 @@ check_constraint_table_args = [
 
 
 def upgrade():
-    with op.batch_alter_table("runs", table_args=check_constraint_table_args) as batch_op:
-        # Transform the "status" column to an `Enum` and define a new check constraint. Specify
-        # `native_enum=False` to create a check constraint rather than a
-        # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
-        # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
-        batch_op.alter_column(
-            "status", type_=Enum(*new_run_statuses, create_constraint=True, native_enum=False)
-        )
+    new_type = Enum(*new_run_statuses, create_constraint=True, native_enum=False)
+    if Version(alembic.__version__) < Version("1.7.0"):
+        with op.batch_alter_table("runs", table_args=check_constraint_table_args) as batch_op:
+            # Transform the "status" column to an `Enum` and define a new check constraint. Specify
+            # `native_enum=False` to create a check constraint rather than a
+            # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
+            # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
+            batch_op.alter_column("status", type_=new_type)
+    else:
+        # In alembic >= 1.7.0, `table_args` can be removed since CHECK constraints are preserved.
+        with op.batch_alter_table("runs") as batch_op:
+            existing_type = Enum(
+                *old_run_statuses, create_constraint=True, native_enum=False, name="status"
+            )
+            batch_op.alter_column(
+                "status",
+                type_=new_type,
+                # In alembic >= 1.7.0, `existing_type` is required to drop the existing CHECK
+                # constraint on the status column.
+                existing_type=existing_type,
+            )
 
 
 def downgrade():

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ Server & UI. It also adds project backends such as Docker and Kubernetes among
 other capabilities.
 """
 CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
-    "alembic<1.7.0",
+    "alembic",
     # Required
     "docker>=4.0.0",
     "Flask",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ Server & UI. It also adds project backends such as Docker and Kubernetes among
 other capabilities.
 """
 CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
-    "alembic<=1.4.1",
+    "alembic",
     # Required
     "docker>=4.0.0",
     "Flask",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ Server & UI. It also adds project backends such as Docker and Kubernetes among
 other capabilities.
 """
 CORE_REQUIREMENTS = SKINNY_REQUIREMENTS + [
-    "alembic",
+    "alembic<1.7.0",
     # Required
     "docker>=4.0.0",
     "Flask",


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
