### PR TITLE
Test: measure setup-uv API rate limit consumption

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -49,9 +49,19 @@ runs:
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ steps.get-python-version.outputs.version }}
+    - name: Rate limit before setup-uv
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: echo "Rate limit before setup-uv:$(gh api rate_limit --jq '.rate.remaining')"
     - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
         resolution-strategy: "lowest"
+    - name: Rate limit after setup-uv
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: echo "Rate limit after setup-uv:$(gh api rate_limit --jq '.rate.remaining')"
     - run: |
         # The default `first-index` strategy is too strict. Use `unsafe-first-match` instead.
         # https://docs.astral.sh/uv/configuration/environment/#uv_index_strategy

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -56,7 +56,7 @@ runs:
       run: echo "Rate limit before setup-uv:$(gh api rate_limit --jq '.rate.remaining')"
     - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
-        resolution-strategy: "lowest"
+        version: "0.10.12"
     - name: Rate limit after setup-uv
       shell: bash
       env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,7 +47,6 @@ jobs:
   # The python skinny tests cover the subset of mlflow functionality
   # while also verifying certain dependencies are omitted.
   python-skinny:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -64,7 +63,7 @@ jobs:
           ./dev/run-python-skinny-tests.sh
 
   python:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -119,7 +118,7 @@ jobs:
             pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
 
   database:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -177,7 +176,7 @@ jobs:
           ./tests/db/compose.sh down --volumes --remove-orphans --rmi all
 
   java:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -199,7 +198,7 @@ jobs:
           uv run --no-dev mvn clean package -q
 
   flavors:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -226,7 +225,7 @@ jobs:
             tests/autologging
 
   models:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -260,7 +259,7 @@ jobs:
           uv run --no-sync pytest --splits=$SPLITS --group=$GROUP tests/models
 
   evaluate:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -296,7 +295,7 @@ jobs:
           uv run --no-sync pytest tests/evaluate/test_default_evaluator_delta.py
 
   genai:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -326,7 +325,7 @@ jobs:
             --ignore tests/genai/optimize --ignore tests/genai/prompts
 
   pyfunc:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -364,7 +363,7 @@ jobs:
           uv run --no-sync pytest tests/pyfunc/test_spark_connect.py
 
   windows:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
+    if: false
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:


### PR DESCRIPTION
Measures GitHub API rate limit before and after `setup-uv` to quantify consumption.

Only `python-skinny` job is enabled to keep the test fast.